### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# fluent-plugin-config-expander, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-config-expander
+
+This is a plugin for [Fluentd](http://fluentd.org).
 
 ## ConfigExpanderInput, ConfigExpanderOutput
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
