### PR TITLE
fix tests to use router.emit instead of Engine.emit

### DIFF
--- a/test/plugins.rb
+++ b/test/plugins.rb
@@ -49,9 +49,14 @@ class Fluent::ConfigExpanderTestOutput < Fluent::Output
     @stopped = true
   end
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   def emit(tag, es, chain)
     es.each do |time, record|
-      Fluent::Engine.emit(@tag, time, record.merge({'over' => 'expander'}))
+      router.emit(@tag, time, record.merge({'over' => 'expander'}))
     end
     chain.next
   end


### PR DESCRIPTION
With v0.14, `Engine.emit` was completely dropped. To run tests with v0.14, the test codes must be fixed. Otherwise, we get errors as:

```
Error: test_emit(ConfigExpanderOutputTest): RuntimeError: BUG: use router.emit instead of Engine.emit
/Users/seo.naotoshi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/fluentd-af46b723b0eb/lib/fluent/engine.rb:132:in `emit'
/Users/seo.naotoshi/src/github.com/tagomoris/fluent-plugin-config-expander/test/plugins.rb:54:in `block in emit'
/Users/seo.naotoshi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/fluentd-af46b723b0eb/lib/fluent/event.rb:74:in `each'
/Users/seo.naotoshi/src/github.com/tagomoris/fluent-plugin-config-expander/test/plugins.rb:53:in `emit'
/Users/seo.naotoshi/src/github.com/tagomoris/fluent-plugin-config-expander/lib/fluent/plugin/out_config_expander.rb:58:in `emit'
/Users/seo.naotoshi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/fluentd-af46b723b0eb/lib/fluent/compat/output.rb:158:in `process'
/Users/seo.naotoshi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/fluentd-af46b723b0eb/lib/fluent/plugin/bare_output.rb:48:in `emit_sync'
/Users/seo.naotoshi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/fluentd-af46b723b0eb/lib/fluent/test/output_test.rb:46:in `emit'
/Users/seo.naotoshi/src/github.com/tagomoris/fluent-plugin-config-expander/test/plugin/test_out_config_expander.rb:67:in `block in test_emit'
```