### PR TITLE
Use router.emit in test class

### DIFF
--- a/test/plugins.rb
+++ b/test/plugins.rb
@@ -51,7 +51,7 @@ class Fluent::ConfigExpanderTestOutput < Fluent::Output
 
   def emit(tag, es, chain)
     es.each do |time, record|
-      Fluent::Engine.emit(@tag, time, record.merge({'over' => 'expander'}))
+      router.emit(@tag, time, record.merge({'over' => 'expander'}))
     end
     chain.next
   end


### PR DESCRIPTION
This PR uses `router.emit` instead of `Engine#emit`.
But it is still remaining uninitialized constant `Fluent::Input`.

Related to https://github.com/fluent/fluentd/issues/973.