### PR TITLE
Require fluent/input explicitly

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/input'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|


### PR DESCRIPTION
This PR fixes `Fluent::Input` uninitialized constant error.
Previous `fluent/test` requires `fluent/load`.
But now, `fluent/test` does not require it.
This error should solve in plugin side not Fluentd itself.

Related to https://github.com/fluent/fluentd/issues/973.