### PR TITLE
fix tests to pass in v0.14

### DIFF
--- a/test/plugin/test_expander.rb
+++ b/test/plugin/test_expander.rb
@@ -78,7 +78,7 @@ EOL
 <config>
   type forward
   flush_interval 1s
-  <for nodenum in 01 02 >
+  <for nodenum in 01 02>
     <for portnum in 24221 24222 24223 24224>
       <server>
         host node__nodenum__.local


### PR DESCRIPTION
With v0.14, test failed as

```
Failure: test_expand(ConfigExpanderTest)
/Users/seo.naotoshi/src/github.com/tagomoris/fluent-plugin-config-expander/test/plugin/test_expander.rb:92:in `test_expand'
     89: </config>
     90: EOL
     91:     conf3 = Fluent::Config.parse(nonexconf3, 'hoge').elements.first
  => 92:     assert_equal nonexconf3, conf3.to_s
     93:     exconf3 = <<EOL
     94: <config>
     95:   type forward
<"<config>\n  type forward\n  flush_interval 1s\n  <for nodenum in 01 02 >\n    <for portnum in 24221 24222 24223 24224>\n      <server>\n        host node__nodenum__.local\n        port __portnum__\n      </server>\n    </for>\n  </for>\n</config>\n"> expected bu
t was
<"<config>\n  type forward\n  flush_interval 1s\n  <for nodenum in 01 02>\n    <for portnum in 24221 24222 24223 24224>\n      <server>\n        host node__nodenum__.local\n        port __portnum__\n      </server>\n    </for>\n  </for>\n</config>\n">
```