### PR TITLE
Handle v0.14 plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: false
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.1
 before_install:
   - gem update bundler

--- a/lib/fluent/plugin/out_config_expander.rb
+++ b/lib/fluent/plugin/out_config_expander.rb
@@ -55,6 +55,10 @@ class Fluent::ConfigExpanderOutput < Fluent::MultiOutput
   end
 
   def emit(tag, es, chain)
-    @plugin.emit(tag, es, chain)
+    if @plugin.respond_to?(:emit_events)
+      @plugin.emit_events(tag, es)
+    else
+      @plugin.emit(tag, es, chain)
+    end
   end
 end

--- a/test/plugin/test_out_config_expander.rb
+++ b/test/plugin/test_out_config_expander.rb
@@ -18,6 +18,19 @@ type config_expander
   </for>
 </config>
 ]
+
+  CONFIG_V14 = %[
+type config_expander
+<config>
+  type config_expander_test_v14
+  tag foobar
+  <for x in 1 2 3>
+    <node>
+      attr1 __x__
+    </node>
+  </for>
+</config>
+]
   def create_driver(conf=CONFIG, tag='test.default')
     Fluent::Test::OutputTestDriver.new(Fluent::ConfigExpanderOutput, tag).configure(conf)
   end
@@ -63,6 +76,30 @@ hostname testing.node.local
 
   def test_emit
     d = create_driver
+    d.run do
+      d.emit({'field' => 'value1'})
+      d.emit({'field' => 'value2'})
+      d.emit({'field' => 'value3'})
+    end
+
+    emits = d.emits
+    assert_equal 3, emits.size
+
+    assert_equal 'foobar', emits[0][0]
+    assert_equal 'value1', emits[0][2]['field']
+    assert_equal 'expander', emits[0][2]['over']
+
+    assert_equal 'foobar', emits[1][0]
+    assert_equal 'value2', emits[1][2]['field']
+    assert_equal 'expander', emits[1][2]['over']
+
+    assert_equal 'foobar', emits[2][0]
+    assert_equal 'value3', emits[2][2]['field']
+    assert_equal 'expander', emits[2][2]['over']
+  end
+
+  def test_emit_v14
+    d = create_driver CONFIG_V14
     d.run do
       d.emit({'field' => 'value1'})
       d.emit({'field' => 'value2'})

--- a/test/plugins.rb
+++ b/test/plugins.rb
@@ -61,3 +61,39 @@ class Fluent::ConfigExpanderTestOutput < Fluent::Output
     chain.next
   end
 end
+
+require 'fluent/plugin/output'
+
+class Fluent::ConfigExpanderV14TestOutput < Fluent::Output
+  Fluent::Plugin.register_output('config_expander_test_v14', self)
+
+  helpers :event_emitter
+
+  config_param :tag, :string
+  attr_accessor :nodes
+  attr_accessor :started, :stopped
+
+  def configure(conf)
+    super
+    @nodes = []
+    conf.elements.each do |e|
+      next if e.name != 'node'
+      @nodes << {}.merge(e)
+    end
+    @started = @stopped = false
+  end
+  def start
+    super
+    @started = true
+  end
+  def shutdown
+    super
+    @stopped = true
+  end
+
+  def process(tag, es)
+    es.each do |time, record|
+      router.emit(@tag, time, record.merge({'over' => 'expander'}))
+    end
+  end
+end


### PR DESCRIPTION
Currently, `fluent-plugin-config-expander` is one of the well known and used plugin.
I've tried to handle v0.14 plugin like as `fluent-plugin-forest`.
Should we handle v0.14 output in this plugin?