### PR TITLE
Enable to output expand config as debug log

### DIFF
--- a/lib/fluent/plugin/filter_config_expander.rb
+++ b/lib/fluent/plugin/filter_config_expander.rb
@@ -32,6 +32,8 @@ class Fluent::Plugin::ConfigExpanderFilter < Fluent::Plugin::Filter
     super
 
     ex = expand_config(@config_config.corresponding_config_element)
+    log.debug "[#{self.class.name}] expand config: \n" + ex.to_s
+
     type = ex['@type']
     @plugin = Fluent::Plugin.new_input(type)
     @plugin.context_router = self.event_emitter_router(conf['@label'])

--- a/lib/fluent/plugin/in_config_expander.rb
+++ b/lib/fluent/plugin/in_config_expander.rb
@@ -32,6 +32,8 @@ class Fluent::Plugin::ConfigExpanderInput < Fluent::Plugin::Input
     super
 
     ex = expand_config(@config_config.corresponding_config_element)
+    log.debug "[#{self.class.name}] expand config: \n" + ex.to_s
+
     type = ex['@type']
     @plugin = Fluent::Plugin.new_input(type)
     @plugin.context_router = self.event_emitter_router(conf['@label'])

--- a/lib/fluent/plugin/out_config_expander.rb
+++ b/lib/fluent/plugin/out_config_expander.rb
@@ -34,6 +34,8 @@ class Fluent::Plugin::ConfigExpanderOutput < Fluent::Plugin::BareOutput
     super
 
     ex = expand_config(@config_config.corresponding_config_element)
+    log.debug "[#{self.class.name}] expand config: \n" + ex.to_s
+
     type = ex['@type']
     @plugin = Fluent::Plugin.new_output(type)
     @plugin.context_router = self.event_emitter_router(conf['@label'])


### PR DESCRIPTION
For convenience :)

output example:
```
...
2017-09-21 16:36:06 +0900 [debug]: #0 fluent/log.rb:296:call: [Fluent::Plugin::ConfigExpanderOutput] expand config:
<match>
  @type stdout
  output_type json
</match>

...
2017-09-21 16:36:06 +0900 [debug]: #0 fluent/log.rb:296:call: [Fluent::Plugin::ConfigExpanderInput] expand config:
<source>
  @type forward
</source>

```